### PR TITLE
[message通知機能の修正]

### DIFF
--- a/app/controllers/users/messages_controller.rb
+++ b/app/controllers/users/messages_controller.rb
@@ -31,6 +31,8 @@ class Users::MessagesController < ApplicationController
   def create
     @message = current_user.messages.new(message_params)
     @message.save
+    # message機能に通知機能を加える際に非同期通信に影響が出る部分
+  
     # if Entry.where(user_id: current_user.id, room_id: params[:message][:room_id]).present?
     #   @message = current_user.messages.new(message_params)
     #   @room=@message.room


### PR DESCRIPTION
message.controllerのcreateの記述を変更する際にcreateの記述を変更してしまうと非同期通信にエラーが出てしまいmessage送信後上手く作動しない。